### PR TITLE
Update pack.py

### DIFF
--- a/pack.py
+++ b/pack.py
@@ -299,13 +299,13 @@ if (USE_XGIMI_CRC2):
 		print ('[i]     Magic: {}'.format(MAGIC_FOOTER))
 		part.write(MAGIC_FOOTER.encode())
 		print ('[i]     Header CRC: 0x{:02X}'.format(headerCRC))
-		part.write(struct.pack('L', headerCRC))
+		part.write(struct.pack('<L', headerCRC))
 	
 	# Step #2 Calculate CRC2
 	mergedCRC = utils.crc32(mergedPart)
 	with open(footerPart, 'wb') as footer:
 		print ('[i]     Merged CRC: 0x{:02X}'.format(mergedCRC))
-		footer.write(struct.pack('L', mergedCRC))
+		footer.write(struct.pack('<L', mergedCRC))
 		print ('[i]     First 16 bytes of header: {}'.format(header16bytes))
 		footer.write(header16bytes)
 
@@ -321,9 +321,9 @@ else:
 		print ('[i]     Magic: {}'.format(MAGIC_FOOTER))
 		footer.write(MAGIC_FOOTER.encode())
 		print ('[i]     Header CRC: 0x{:02X}'.format(headerCRC))
-		footer.write(struct.pack('L', headerCRC)) # struct.pack('L', data) <- returns byte swapped data
+		footer.write(struct.pack('<L', headerCRC)) # struct.pack('L', data) <- returns byte swapped data
 		print ('[i]     Bin CRC: 0x{:02X}'.format(binCRC))
-		footer.write(struct.pack('L', binCRC))
+		footer.write(struct.pack('<L', binCRC))
 		print ('[i]     First 16 bytes of header: {}'.format(header16bytes))
 		footer.write(header16bytes)
 


### PR DESCRIPTION
Force little-endian byte ordering for storing CRCs to script file. Otherwise, the length stored is platform dependent (see https://docs.python.org/3/library/struct.html). Otherwise on a 64 bit system CRCs get packed at 8 byte longs, which makes MBoot unhappy.