### PR TITLE
Update unpack.py. Fix UTF-8 error.

### DIFF
--- a/unpack.py
+++ b/unpack.py
@@ -40,16 +40,8 @@ header = utils.loadPart(inputFile, 0, HEADER_SIZE)
 utils.copyPart(inputFile, os.path.join(outputDirectory, "~header"), 0, HEADER_SIZE)
 
 offset = header.find('\xff'.encode(encoding='iso-8859-1'))
-if offset != -1:
-	headerScript = header[:offset].decode()
-	headerScriptFound = True
 
-if not headerScriptFound:
-	print ("[!] Could not find header script!")
-	quit()
-	
-if DEBUG:
-	print (headerScript)
+headerScriptFound = True
 
 # Save the script
 print ("[i] Saving header script to " + os.path.join(outputDirectory, "~header_script") + " ...")


### PR DESCRIPTION
Quick and dirty fix for unpacking HomeWorX MSD7816 firmware. Fixes UTF-8 Error.